### PR TITLE
Change parameter name passed to read_grid in verify_spatial

### DIFF
--- a/R/verify_spatial.R
+++ b/R/verify_spatial.R
@@ -210,7 +210,7 @@ verify_spatial <- function(dttm,
       try(
         do.call(harpIO::read_grid,
             c(list(file_name = fcfile, file_format = fc_file_format,
-                       parameter = parameter, lead_time = lead_time,
+                       parameter = prm$basename, lead_time = lead_time,
                        file_format_opts = fc_file_opts)))
       )
     }
@@ -230,13 +230,13 @@ verify_spatial <- function(dttm,
         try(
           do.call(harpIO::read_grid,
                   c(list(file_name = fcfile, file_format = fc_file_format,
-                    parameter = parameter, lead_time = lead_time),
+                    parameter = prm$basename, lead_time = lead_time),
                     fc_file_opts))
           )
       } else {
         try(
           lapply(fcfile, harpIO::read_grid, file_format = fc_file_format,
-                  parameter = parameter, lead_time = lead_time, members=members,
+                  parameter = prm$basename, lead_time = lead_time, members=members,
                   unlist(fc_file_opts))
           )
       }


### PR DESCRIPTION
As suggested by Andrew. Solves problem when using "parameter = AccPcp3h" in verify_spatial.