### PR TITLE
Remove one lead time condition

### DIFF
--- a/R/verify_spatial.R
+++ b/R/verify_spatial.R
@@ -143,11 +143,10 @@ verify_spatial <- function(dttm,
 
   # convert lead_time to seconds and remove lead_times smaller than accum
   # we don't have 3h precip at 0h forecast.
-  # also, we probably want lead_time in steps of the accumulation
   lt_scale <- harpIO:::units_multiplier(lt_unit)
   lead_time <- lead_time * lt_scale
   if (prm$accum > 0) {
-    lead_time <- lead_time[which(lead_time >= prm$accum & lead_time %% prm$accum == 0)]
+    lead_time <- lead_time[which(lead_time >= prm$accum)]
   }
   # dttm is a vector of STRINGS
   # we want datetime objects to which we can add the lead_time


### PR DESCRIPTION
I suggest to make the lead times a bit more flexible.

One might be interested in more lead times than those that are evenly dividable by the accumulation time. 

Let's say to compare e.g. an event that peaks at 10 or 11 UTC and you also want to see 3 hour or 6 hour accumulation of run 00 or 06.
