### PR TITLE
Feature/add param defs

### DIFF
--- a/R/verify_spatial.R
+++ b/R/verify_spatial.R
@@ -64,6 +64,10 @@
 #'   from the start of the model run. That is probably rare for observations.
 #'   Otherwise this should be a string containing a numerical value
 #'   and a time unit, e.g. "15m" or "1h". "0" means an instantaneous value.
+#' @param ob_param_defs A list of parameter definitions that includes the file
+#'          format to be read. By default the built in list ‘harp_params’
+#'          is used. Modifications and additions to this list can be made
+#'          using ‘modify_param_def’ and ‘add_param_def’ respectively.
 #' @param verif_domain A \code{geodomain} that defines the common verification grid.
 #' @param return_data          = TRUE,
 #' @param thresholds Thresholds used for FSS, ...
@@ -99,6 +103,7 @@ verify_spatial <- function(dttm,
                            ob_file_template     = harpSpatial_conf$ob_file_template, #"",
                            ob_file_format       = harpSpatial_conf$ob_file_format, #"hdf5",
                            ob_file_opts         = harpSpatial_conf$ob_file_opts, #list(),
+			   ob_param_defs        = getExportedValue("harpIO", "harp_params"),
                            ob_domain            = harpSpatial_conf$ob_domain, #NULL,
                            ob_interp_method     = harpSpatial_conf$ob_interp_method, #"closest",
                            ob_accumulation      = harpSpatial_conf$ob_accumulation, #"15m",
@@ -188,8 +193,11 @@ verify_spatial <- function(dttm,
     )
     # FIXME: first check that the file exists! Avoid Errors. Use 
     try(do.call(harpIO::read_grid,
-                  c(list(file_name=obfile, file_format=ob_file_format,
-                         parameter = ob_param, file_format_opts = ob_file_opts))),
+                  c(list(file_name        = obfile,
+			 file_format      = ob_file_format,
+			 parameter        = ob_param,
+			 file_format_opts = ob_file_opts,
+			 param_defs       = ob_param_defs))),
         silent = TRUE) 
   }
 

--- a/R/verify_spatial.R
+++ b/R/verify_spatial.R
@@ -41,6 +41,10 @@
 #'   accumulated parameters (e.g. precipitation). NULL signifies that the field is accumulated
 #'   from the start of the model run. Otherwise this should be a string containing a numerical value
 #'   and a time unit, e.g. "15m" or "1h".
+#' @param fc_param_defs A list of parameter definitions that includes the file
+#'          format to be read. By default the built in list ‘harp_params’
+#'          is used. Modifications and additions to this list can be made
+#'          using ‘modify_param_def’ and ‘add_param_def’ respectively.
 #' @param ob_file_path The top level path for the forecast files to read.
 #' @param ob_file_template The file type to generate the template for. Can be
 #'   "harmoneps_grib", "harmeoneps_grib_fp", "harmoneps_grib_sfx", "meps_met",
@@ -96,6 +100,7 @@ verify_spatial <- function(dttm,
                            fc_file_template     = harpSpatial_conf$fc_file_template, #"",
                            fc_file_format       = harpSpatial_conf$fc_file_format, #"fa",
                            fc_file_opts         = harpSpatial_conf$fc_file_opts, #list(),
+			   fc_param_defs        = getExportedValue("harpIO", "harp_params"),
                            fc_domain            = harpSpatial_conf$fc_domain, #NULL,
                            fc_interp_method     = harpSpatial_conf$fc_interp_method, #"closest",
                            fc_accumulation      = harpSpatial_conf$fc_accumulation, #NULL,
@@ -217,9 +222,12 @@ verify_spatial <- function(dttm,
         file_template = fc_file_template)
       try(
         do.call(harpIO::read_grid,
-            c(list(file_name = fcfile, file_format = fc_file_format,
-                       parameter = parameter, lead_time = lead_time,
-                       file_format_opts = fc_file_opts)))
+            c(list(file_name        = fcfile,
+		   file_format      = fc_file_format,
+		   parameter        = parameter,
+		   lead_time        = lead_time,
+		   file_format_opts = fc_file_opts,
+		   param_defs       = fc_param_defs)))
       )
     }
   } else {


### PR DESCRIPTION
Hi @adeckmyn,

those changes allow passing the option param_defs on to read_grid for both observations and forecasts. 
To set param_defs in the reading routine is relevant for e.g. some arome files.

Cheers
