### PR TITLE
Clarify info message

### DIFF
--- a/R/verify_spatial.R
+++ b/R/verify_spatial.R
@@ -362,7 +362,8 @@ verify_spatial <- function(dttm,
       ldt <- (as.numeric(obdate) - as.numeric(fcdate)) # in seconds !
       message(
         "   +++ fcdate = ", format(fcdate,"%Y%m%d-%H%M"),
-        " +++ ldt = ", ldt / lt_scale, lt_unit
+        " +++ ldt = ", ldt / lt_scale, 
+	", ldt unit =  ", lt_unit
       )
 
       fcfield <- get_fc(fcdate, ldt/lt_scale)


### PR DESCRIPTION
Hi @adeckmyn,

Just a small change to make the info message on the screen more clear.

e.g.
+++ fcdate = 20250930-1200 +++ ldt = **81h**
becomes
+++ fcdate = 20250930-1200 +++ ldt = **8, ldt unit =  1h**